### PR TITLE
完善了对删除cookie的说明

### DIFF
--- a/source/helpers/cookie_helper.rst
+++ b/source/helpers/cookie_helper.rst
@@ -62,7 +62,6 @@ Cookie 辅助函数文件包含了一些帮助你处理 Cookie 的函数。
 
 	删除一条 Cookie，只需要传入 Cookie 名即可，也可以设置路径或其他参数
 	来删除特定 Cookie。
-	将domain设置为你的URL,否则将无法删除cookie
 	添加cookie时候设置domin,删除时，domain为必填项，将domain设置为你的URL,否则将无法删除cookie
 	::
 

--- a/source/helpers/cookie_helper.rst
+++ b/source/helpers/cookie_helper.rst
@@ -62,6 +62,8 @@ Cookie 辅助函数文件包含了一些帮助你处理 Cookie 的函数。
 
 	删除一条 Cookie，只需要传入 Cookie 名即可，也可以设置路径或其他参数
 	来删除特定 Cookie。
+	将domain设置为你的URL,否则将无法删除cookie
+	添加cookie时候设置domin,删除时，domain为必填项，将domain设置为你的URL,否则将无法删除cookie
 	::
 
 		delete_cookie('name');

--- a/source/libraries/input.rst
+++ b/source/libraries/input.rst
@@ -271,7 +271,7 @@ CodeIgniter 为你解决了这个问题，你只需要使用下面的 ``$raw_inp
 
 		**注意**
 
-		只有 name 和 value 两项是必须的，要删除 COOKIE 的话，将 expire 设置为空。
+		只有 name 和 value 两项是必须的，要删除 COOKIE 的话，将 expire 设置为空,将domain设置为你的URL,否则将无法删除cookie。
 
 		COOKIE 的过期时间是 **秒** ，将它加到当前时间上就是 COOKIE 的过期时间。
 		记住不要把它设置成时间了，只要设置成距离当前时间的秒数即可，那么在这段


### PR DESCRIPTION
在设置cookie时，使用了domain 属性，删除此cookie时未设置domain属性造成cookie删除失败。
在删除设置了domain属性的cookie时，domain属性为必填项，不可为空，否则将造成cookie删除失败